### PR TITLE
#311 More Generics fixes

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
@@ -91,25 +91,36 @@ abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet implemen
 
     protected Type firstGenericType(MethodParameter param) {
         Type type = param.getGenericParameterType();
-        if (type != null && type instanceof ParameterizedType) {
+        if(type instanceof TypeVariable) {
+            TypeVariable tv = (TypeVariable)type;
+            return findTypeFromTypeVariable(tv, param.getContainingClass());
+        }
+        else if (type instanceof ParameterizedType) {
             ParameterizedType parameterizedType = (ParameterizedType) type;
             Type actualArgument = parameterizedType.getActualTypeArguments()[0];
-            if(actualArgument instanceof Class) {
+            if (actualArgument instanceof Class) {
                 return actualArgument;
-            } else if(actualArgument instanceof TypeVariable) {
-                TypeVariable typeVariable = (TypeVariable)actualArgument;
-                String variableName = typeVariable.getName();
-                Map<TypeVariable, Type> typeMap = GenericTypeResolver.getTypeVariableMap(param.getContainingClass());
-                for(TypeVariable tv : typeMap.keySet()) {
-                    if(StringUtils.equals(tv.getName(), variableName)) {
-                        return typeMap.get(tv);
-                    }
-                }
+            } else if (actualArgument instanceof TypeVariable) {
+                TypeVariable typeVariable = (TypeVariable) actualArgument;
+                return findTypeFromTypeVariable(typeVariable, param.getContainingClass());
             }
             return ((ParameterizedType) type).getActualTypeArguments()[0];
         } else {
             return Object.class;
         }
+    }
+
+    protected Type findTypeFromTypeVariable(TypeVariable typeVariable, Class<?> clazz) {
+        Type defaultReturnValue = Object.class;
+
+        String variableName = typeVariable.getName();
+        Map<TypeVariable, Type> typeMap = GenericTypeResolver.getTypeVariableMap(clazz);
+        for(TypeVariable tv : typeMap.keySet()) {
+            if(StringUtils.equals(tv.getName(), variableName)) {
+                return typeMap.get(tv);
+            }
+        }
+        return defaultReturnValue;
     }
 
     protected abstract Type getType(HandlerMethod method);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -76,7 +76,10 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
             };
         } else if ("void".equals(returnType.getName())) {
             return null;
-        } else {
+        } else if (method.getReturnType().getGenericParameterType() != null) {
+            return firstGenericType(method.getReturnType());
+        }
+        else {
             return returnType;
         }
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -21,6 +21,7 @@ package capital.scalable.restdocs.payload;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Map;
 
 import org.springframework.http.HttpEntity;
@@ -76,7 +77,7 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
             };
         } else if ("void".equals(returnType.getName())) {
             return null;
-        } else if (method.getReturnType().getGenericParameterType() != null) {
+        } else if (method.getReturnType().getGenericParameterType() instanceof TypeVariable) {
             return firstGenericType(method.getReturnType());
         }
         else {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -326,8 +326,10 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 .build());
     }
 
+
+
     @Test
-    public void genericSuperMethod() throws Exception {
+    public void genericSuperMethodCollection() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("getItemsGeneric");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
@@ -336,6 +338,25 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 tableWithHeader("Path", "Type", "Optional", "Description")
                         .row("[].field1", "String", "true", "A string.")
                         .row("[].field2", "Decimal", "true", "A decimal."));
+
+        new JacksonResponseFieldSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+    }
+
+    @Test
+    public void genericSuperMethodSingleItem() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("getItemGeneric");
+        mockFieldComment(Item.class, "field1", "A string");
+        mockFieldComment(Item.class, "field2", "A decimal");
+
+        this.snippets.expect(RESPONSE_FIELDS).withContents(
+                tableWithHeader("Path", "Type", "Optional", "Description")
+                        .row("field1", "String", "true", "A string.")
+                        .row("field2", "Decimal", "true", "A decimal."));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -402,6 +423,10 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         @Override
         public List<E> getItemsGeneric() {
             return Collections.singletonList(createGeneric());
+        }
+
+        public E getItemGeneric() {
+            return createGeneric();
         }
     }
 


### PR DESCRIPTION
AbstractJacksonFieldSnippet.java
- Handle the cases there MethodParameter is a TypeVariable

JacksonResponseFieldSnippet.java
- Handle the cases where the return type is a TypeVariable
-- public E getItem()

JacksonResponseFieldSnippetTest.java
- Tests cases for TypeVariable return type