### PR TITLE
#311 More Generics fixes

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ import static capital.scalable.restdocs.i18n.SnippetTranslationResolver.translat
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Map;
 
 import capital.scalable.restdocs.jackson.FieldDescriptors;
@@ -83,6 +84,8 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
             }
         } else if (REACTOR_FLUX_CLASS.equals(returnType.getCanonicalName())) {
             return (GenericArrayType) () -> firstGenericType(method.getReturnType());
+        } else if (method.getReturnType().getGenericParameterType() instanceof TypeVariable) {
+            return firstGenericType(method.getReturnType());
         } else {
             return returnType;
         }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -433,7 +433,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
     }
 
     @Test
-    public void genericSuperMethod() throws Exception{
+    public void genericSuperMethodCollection() throws Exception{
         HandlerMethod handlerMethod = createHandlerMethod("getItemsGeneric");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
@@ -450,6 +450,25 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                         .row("[].field1", "String", "true", "A string.")
                         .row("[].field2", "Decimal", "true", "A decimal."));
 
+    }
+
+    @Test
+    public void genericSuperMethodSingleItem() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("getItemGeneric");
+        mockFieldComment(Item.class, "field1", "A string");
+        mockFieldComment(Item.class, "field2", "A decimal");
+
+        new JacksonResponseFieldSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+
+        assertThat(this.generatedSnippets.snippet(AUTO_RESPONSE_FIELDS)).is(
+                tableWithHeader("Path", "Type", "Optional", "Description")
+                        .row("field1", "String", "true", "A string.")
+                        .row("field2", "Decimal", "true", "A decimal."));
     }
 
 
@@ -510,6 +529,10 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         @Override
         public List<E> getItemsGeneric() {
             return Collections.singletonList(createGeneric());
+        }
+
+        public E getItemGeneric() {
+            return createGeneric();
         }
     }
 


### PR DESCRIPTION
AbstractJacksonFieldSnippet.java
- Handle the cases there MethodParameter is a TypeVariable

JacksonResponseFieldSnippet.java
- Handle the cases where the return type is a TypeVariable
-- public E getItem()

JacksonResponseFieldSnippetTest.java
- Tests cases for TypeVariable return type